### PR TITLE
set time_in_force on orders to 'day'

### DIFF
--- a/tests/test_alpaca_trade_manager.py
+++ b/tests/test_alpaca_trade_manager.py
@@ -39,7 +39,7 @@ class TestAlpacaTradeManager(unittest.TestCase):
             ),
             side='buy',
             type='market',
-            time_in_force='gtc'
+            time_in_force='day'
         )
         
 

--- a/trade_bot/alpaca_trade_manager.py
+++ b/trade_bot/alpaca_trade_manager.py
@@ -39,7 +39,7 @@ class AlpacaTradeManager:
             ),
             side='buy',
             type='market',
-            time_in_force='gtc'
+            time_in_force='day'
         )
 
 


### PR DESCRIPTION
Received error on submit order for fractional trade
```
alpaca_trade_api.rest.APIError: fractional orders must be DAY orders
```
Pr should resolve