### PR TITLE
Catch Insufficient Funds

### DIFF
--- a/core/alpaca/alpaca_trade_manager.py
+++ b/core/alpaca/alpaca_trade_manager.py
@@ -1,7 +1,6 @@
-from alpaca_trade_api.rest import REST, TimeFrame
+from alpaca_trade_api.rest import REST, APIError, TimeFrame
 import pandas as pd
 from typing import Any, List, Optional
-from alpaca_trade_api.rest import APIError 
 import logging 
 
 class AlpacaTradeManager:

--- a/core/alpaca/alpaca_trade_manager.py
+++ b/core/alpaca/alpaca_trade_manager.py
@@ -1,6 +1,8 @@
 from alpaca_trade_api.rest import REST, TimeFrame
 import pandas as pd
 from typing import Any, List, Optional
+from alpaca_trade_api.rest import APIError 
+import logging 
 
 class AlpacaTradeManager:
     timeframes = {
@@ -58,9 +60,8 @@ class AlpacaTradeManager:
                 type='market',
                 time_in_force='day'
             )
-        except:
-            print('Insufficient Funds')
-
+        except APIError as e:
+            logging.error(f"Alpaca APIError: {e}")
 
     def sell_stock(self, ticker: str) -> None:
         """
@@ -73,7 +74,6 @@ class AlpacaTradeManager:
             type='market',
             time_in_force='gtc'
         )
-
 
     def get_stock_qty(self, ticker: str) -> float:
         """

--- a/core/alpaca/alpaca_trade_manager.py
+++ b/core/alpaca/alpaca_trade_manager.py
@@ -47,16 +47,19 @@ class AlpacaTradeManager:
         purchase_amnt = round(buying_power * 0.05, 2)
         floor = round(purchase_amnt * 0.9, 2)
 
-        self.api.submit_order(
-            symbol=ticker,
-            notional=purchase_amnt,
-            stop_loss=dict(
-              stop_price=floor
-            ),
-            side='buy',
-            type='market',
-            time_in_force='day'
-        )
+        try:
+            self.api.submit_order(
+                symbol=ticker,
+                notional=purchase_amnt,
+                stop_loss=dict(
+                stop_price=floor
+                ),
+                side='buy',
+                type='market',
+                time_in_force='day'
+            )
+        except:
+            print('Insufficient Funds')
 
 
     def sell_stock(self, ticker: str) -> None:

--- a/tests/trade_bot/test_integration_make_orders_bbands_rsi.py
+++ b/tests/trade_bot/test_integration_make_orders_bbands_rsi.py
@@ -35,14 +35,14 @@ def test_make_orders(mock_get_market_day_range, mock_trade_manager, mock_sns_cli
     mock_sns_topic_arn = "arn:aws:sns:us-east-1:123456789101:trade_bot_signals"
     make_orders(trade_manager=mock_trade_manager, Strategy=BBandsRSI, tickers=tickers, sns_client=mock_sns_client, sns_topic_arn=mock_sns_topic_arn)
     
-    # Ensure buy_stock was called for BULLISH signal
-    mock_trade_manager.buy_stock.assert_called_once_with("GOOGL")
-    
     # Ensure sell_stock was called for BEARISH signal
     mock_trade_manager.sell_stock.assert_called_once_with("AAPL")
     
+    # Ensure buy_stock was called for BULLISH signal
+    mock_trade_manager.buy_stock.assert_called_once_with("GOOGL")
+    
     # Ensure SNS publish was called for both buy and sell
     mock_sns_client.publish.assert_has_calls([
-        call(Message='Trade Bot Buy Orders Made: GOOGL',TopicArn=mock_sns_topic_arn),
-        call(Message='Trade Bot Sell Orders Made: AAPL', TopicArn=mock_sns_topic_arn)
+        call(Message='Trade Bot Sell Orders Made: AAPL', TopicArn=mock_sns_topic_arn),
+        call(Message='Trade Bot Buy Orders Made: GOOGL',TopicArn=mock_sns_topic_arn)
     ])

--- a/tests/trade_bot/test_integration_make_orders_engulfing_candlesticks.py
+++ b/tests/trade_bot/test_integration_make_orders_engulfing_candlesticks.py
@@ -39,14 +39,14 @@ def test_make_orders_engulfing_candlesticks(mock_get_market_day_range, mock_trad
 
     make_orders(trade_manager=mock_trade_manager, Strategy=EngulfingCandlesticks, tickers=tickers, sns_client=mock_sns_client, sns_topic_arn=mock_sns_topic_arn)
 
-    # Ensure buy_stock was called for BULLISH signal
-    mock_trade_manager.buy_stock.assert_called_once_with("AAPL")
-    
     # Ensure sell_stock was called for BEARISH signal
     mock_trade_manager.sell_stock.assert_called_once_with("GOOGL")
+    
+    # Ensure buy_stock was called for BULLISH signal
+    mock_trade_manager.buy_stock.assert_called_once_with("AAPL")
 
     # Ensure SNS publish was called for both buy and sell
     mock_sns_client.publish.assert_has_calls([
-        call(Message='Trade Bot Buy Orders Made: AAPL',TopicArn=mock_sns_topic_arn),
-        call(Message='Trade Bot Sell Orders Made: GOOGL', TopicArn=mock_sns_topic_arn)
+        call(Message='Trade Bot Sell Orders Made: GOOGL', TopicArn=mock_sns_topic_arn),
+        call(Message='Trade Bot Buy Orders Made: AAPL',TopicArn=mock_sns_topic_arn)
     ])

--- a/tests/trade_bot/test_integration_make_orders_moving_averages.py
+++ b/tests/trade_bot/test_integration_make_orders_moving_averages.py
@@ -35,14 +35,14 @@ def test_make_orders(mock_get_market_day_range, mock_trade_manager, mock_sns_cli
     mock_sns_topic_arn = "arn:aws:sns:us-east-1:123456789101:trade_bot_signals"
     make_orders(trade_manager=mock_trade_manager, Strategy=MovingAverages, tickers=tickers, sns_client=mock_sns_client, sns_topic_arn=mock_sns_topic_arn)
     
-    # Ensure buy_stock was called for BULLISH signal
-    mock_trade_manager.buy_stock.assert_called_once_with("GOOGL")
-    
     # Ensure sell_stock was called for BEARISH signal
     mock_trade_manager.sell_stock.assert_called_once_with("AAPL")
     
+    # Ensure buy_stock was called for BULLISH signal
+    mock_trade_manager.buy_stock.assert_called_once_with("GOOGL")
+    
     # Ensure SNS publish was called for both buy and sell
     mock_sns_client.publish.assert_has_calls([
-        call(Message='Trade Bot Buy Orders Made: GOOGL',TopicArn=mock_sns_topic_arn),
-        call(Message='Trade Bot Sell Orders Made: AAPL', TopicArn=mock_sns_topic_arn)
+        call(Message='Trade Bot Sell Orders Made: AAPL', TopicArn=mock_sns_topic_arn),
+        call(Message='Trade Bot Buy Orders Made: GOOGL',TopicArn=mock_sns_topic_arn)
     ])

--- a/trade_bot/make_orders.py
+++ b/trade_bot/make_orders.py
@@ -14,7 +14,7 @@ def make_orders(trade_manager: AlpacaTradeManager, Strategy: Strategy, tickers: 
     """
     
     purchased_tickers, sold_tickers = [], []
-    period_start, period_end = get_market_day_range(21) # 21 for 20 day moving avg
+    period_start, period_end = get_market_day_range(365) # 21 for 20 day moving avg
 
     logging.info("Making orders...")
     
@@ -23,7 +23,6 @@ def make_orders(trade_manager: AlpacaTradeManager, Strategy: Strategy, tickers: 
     for ticker in owned_tickers:
         logging.info("Evaluating " + ticker + " for sell")
         df = trade_manager.get_price_data(ticker, period_start, period_end)
-        
         strat = Strategy(df)
         
         if strat.signal() == TradeSignal.BEARISH:

--- a/trade_bot/make_orders.py
+++ b/trade_bot/make_orders.py
@@ -12,9 +12,8 @@ def make_orders(trade_manager: AlpacaTradeManager, Strategy: Strategy, tickers: 
     Makes buy orders for all stocks in the S&P 500 given a bullish signal.
     Makes sell orders for all owned stocks bearish signal.
     """
-    
     purchased_tickers, sold_tickers = [], []
-    period_start, period_end = get_market_day_range(365) # 21 for 20 day moving avg
+    period_start, period_end = get_market_day_range(365) 
 
     logging.info("Making orders...")
     

--- a/trade_bot/make_orders.py
+++ b/trade_bot/make_orders.py
@@ -1,5 +1,4 @@
 from core.alpaca.alpaca_trade_manager import AlpacaTradeManager
-from core.alpaca.alpaca_trade_manager import AlpacaTradeManager
 from core.trading.strategy import Strategy
 from core.models.trade_signal import TradeSignal
 from core.utils.market_time import get_market_day_range
@@ -13,32 +12,20 @@ def make_orders(trade_manager: AlpacaTradeManager, Strategy: Strategy, tickers: 
     Makes buy orders for all stocks in the S&P 500 given a bullish signal.
     Makes sell orders for all owned stocks bearish signal.
     """
+    
     purchased_tickers, sold_tickers = [], []
-    period_start, period_end = get_market_day_range(365)
+    period_start, period_end = get_market_day_range(21) # 21 for 20 day moving avg
 
     logging.info("Making orders...")
-    for ticker in tickers:
-        logging.info("Evaluating " + ticker + " for buy")
-
-        df = trade_manager.get_price_data(ticker, period_start, period_end)
-        strat = Strategy(df)
-
-        if strat.signal() == TradeSignal.BULLISH:
-            trade_manager.buy_stock(ticker)
-            logging.info("Buy order for " + ticker + " placed.")
-            purchased_tickers.append(ticker)
-
-    if purchased_tickers and sns_topic_arn != None:
-        sns_client.publish(Message=f'Trade Bot Buy Orders Made: {", ".join(purchased_tickers)}', TopicArn=sns_topic_arn)
-
+    
     owned_tickers = trade_manager.get_owned_tickers()
 
     for ticker in owned_tickers:
         logging.info("Evaluating " + ticker + " for sell")
-        
         df = trade_manager.get_price_data(ticker, period_start, period_end)
+        
         strat = Strategy(df)
-
+        
         if strat.signal() == TradeSignal.BEARISH:
             trade_manager.sell_stock(ticker)
             logging.info("Sell order for " + ticker + " placed.")
@@ -46,3 +33,18 @@ def make_orders(trade_manager: AlpacaTradeManager, Strategy: Strategy, tickers: 
 
     if sold_tickers and sns_topic_arn != None:
         sns_client.publish(Message=f'Trade Bot Sell Orders Made: {", ".join(sold_tickers)}', TopicArn=sns_topic_arn)
+
+    for ticker in tickers:
+        logging.info("Evaluating " + ticker + " for buy")
+        df = trade_manager.get_price_data(ticker, period_start, period_end)
+        strat = Strategy(df)
+
+        trade_manager.buy_stock(ticker)
+
+        if strat.signal() == TradeSignal.BULLISH:
+            trade_manager.buy_stock(ticker)
+            
+            purchased_tickers.append(ticker)
+
+    if purchased_tickers and sns_topic_arn != None:
+        sns_client.publish(Message=f'Trade Bot Buy Orders Made: {", ".join(purchased_tickers)}', TopicArn=sns_topic_arn)

--- a/trade_bot/make_orders.py
+++ b/trade_bot/make_orders.py
@@ -39,9 +39,8 @@ def make_orders(trade_manager: AlpacaTradeManager, Strategy: Strategy, tickers: 
         df = trade_manager.get_price_data(ticker, period_start, period_end)
         strat = Strategy(df)
 
-        trade_manager.buy_stock(ticker)
-
         if strat.signal() == TradeSignal.BULLISH:
+            trade_manager.buy_stock(ticker)
             
             purchased_tickers.append(ticker)
 

--- a/trade_bot/make_orders.py
+++ b/trade_bot/make_orders.py
@@ -42,7 +42,6 @@ def make_orders(trade_manager: AlpacaTradeManager, Strategy: Strategy, tickers: 
         trade_manager.buy_stock(ticker)
 
         if strat.signal() == TradeSignal.BULLISH:
-            trade_manager.buy_stock(ticker)
             
             purchased_tickers.append(ticker)
 


### PR DESCRIPTION
Reverse order of transaction and catch insufficient buying power.

Set minimum purchase_amnt to 1 to meet notional order value limit.

Changed main for testing purposes and then reverted to version from main branch.

Changed sell time in force to day to stop error "notional orders must be day orders" from throwing.